### PR TITLE
Add Etherscan balance endpoint docs

### DIFF
--- a/api-reference/endpoint/etherscan-balance.mdx
+++ b/api-reference/endpoint/etherscan-balance.mdx
@@ -1,13 +1,13 @@
 ---
-title: 'Get account balance'
+title: 'Get Ether Balance for a Single Address'
 api: 'GET /v2/api'
 ---
 
-Retrieve the balance for a given address on the Etherscan API.
+Returns the Ether balance of a given address.
 
 <ParamFields>
-  <ParamField query="chainid" type="string" initialValue="999">
-    Chain ID of the network.
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID of the network (1 for Ethereum mainnet).
   </ParamField>
   <ParamField query="module" type="string" initialValue="account">
     Module name (set to 'account').
@@ -15,13 +15,21 @@ Retrieve the balance for a given address on the Etherscan API.
   <ParamField query="action" type="string" initialValue="balance">
     Action type (set to 'balance').
   </ParamField>
-  <ParamField query="address" type="string" initialValue="0x388B9FECEDD37A5b9eA44062755f9Ea5bB8d7AE6">
+  <ParamField query="address" type="string" initialValue="0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae">
     Wallet address to query.
   </ParamField>
   <ParamField query="tag" type="string" initialValue="latest">
-    Block tag.
+    Block tag ("earliest", "pending", or "latest").
   </ParamField>
   <ParamField query="apikey" type="string">
     Your Etherscan API key.
   </ParamField>
 </ParamFields>
+
+```
+https://api.etherscan.io/v2/api?chainid=1&module=account&action=balance&address=0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae&tag=latest&apikey=YourApiKeyToken
+```
+
+<Callout icon="link">
+Try this endpoint in your <a href="https://api.etherscan.io/v2/api?chainid=1&module=account&action=balance&address=0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae&tag=latest&apikey=YourApiKeyToken">browser</a>.
+</Callout>

--- a/api-reference/endpoint/etherscan-balance.mdx
+++ b/api-reference/endpoint/etherscan-balance.mdx
@@ -1,0 +1,27 @@
+---
+title: 'Get account balance'
+api: 'GET /v2/api'
+---
+
+Retrieve the balance for a given address on the Etherscan API.
+
+<ParamFields>
+  <ParamField query="chainid" type="string" initialValue="999">
+    Chain ID of the network.
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="account">
+    Module name (set to 'account').
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="balance">
+    Action type (set to 'balance').
+  </ParamField>
+  <ParamField query="address" type="string" initialValue="0x388B9FECEDD37A5b9eA44062755f9Ea5bB8d7AE6">
+    Wallet address to query.
+  </ParamField>
+  <ParamField query="tag" type="string" initialValue="latest">
+    Block tag.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key.
+  </ParamField>
+</ParamFields>

--- a/docs.json
+++ b/docs.json
@@ -47,7 +47,8 @@
           "api-reference/endpoint/get",
           "api-reference/endpoint/create",
           "api-reference/endpoint/delete",
-          "api-reference/endpoint/webhook"
+          "api-reference/endpoint/webhook",
+          "api-reference/endpoint/etherscan-balance"
         ]
       }
     ]
@@ -98,9 +99,12 @@
     }
   },
   "api": {
-    "baseUrl": "https://api.yourdomain.com",
-    "auth": {
-      "method": "bearer"
+    "mdx": {
+      "server": "https://api.etherscan.io",
+      "auth": {
+        "method": "key",
+        "name": "apikey"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- document example Etherscan balance endpoint using MDX
- configure docs.json for MDX-based API docs
- include new page in the navigation sidebar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6866b408ae648333b254aa51c15b58e5