### PR TITLE
Remove unused React import

### DIFF
--- a/snippets/chain-display.jsx
+++ b/snippets/chain-display.jsx
@@ -1,5 +1,3 @@
-import { useState, useEffect } from 'react';
-
 export const ChainDisplay = () => {
   const [chain, setChain] = useState(1);
 


### PR DESCRIPTION
## Summary
- clean up `chain-display.jsx` by removing the React import

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6866be1fd9ec8333b6f508ddf68e6deb