### PR TITLE
Add missing snippet intro

### DIFF
--- a/snippets/snippet-intro.mdx
+++ b/snippets/snippet-intro.mdx
@@ -1,0 +1,1 @@
+One of the core principles of software development is DRY (Don't Repeat Yourself). This is a principle that apply to documentation as well. If you find yourself repeating the same content in multiple places, you should consider creating a custom snippet to keep your content in sync.


### PR DESCRIPTION
## Summary
- add `snippet-intro.mdx` so `essentials/reusable-snippets.mdx` imports work

## Testing
- `grep -R "snippet-intro" -n`

------
https://chatgpt.com/codex/tasks/task_b_6866be4c504c83338c55f2a44d12b9f2