### PR TITLE
feat: list all api-reference endpoints in navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -39,7 +39,19 @@
               {
                 "group": "Account",
                 "pages": [
-                  "api-reference/endpoint/etherscan-balance"
+                  "api-reference/endpoint/etherscan-balance",
+                  "api-reference/endpoint/etherscan-balancehistory",
+                  "api-reference/endpoint/etherscan-balancemulti",
+                  "api-reference/endpoint/etherscan-getminedblocks",
+                  "api-reference/endpoint/etherscan-token1155tx",
+                  "api-reference/endpoint/etherscan-tokennfttx",
+                  "api-reference/endpoint/etherscan-tokentx",
+                  "api-reference/endpoint/etherscan-transactions",
+                  "api-reference/endpoint/etherscan-txlist",
+                  "api-reference/endpoint/etherscan-txlistinternal-blockrange",
+                  "api-reference/endpoint/etherscan-txlistinternal-txhash",
+                  "api-reference/endpoint/etherscan-txlistinternal",
+                  "api-reference/endpoint/etherscan-txsbeaconwithdrawal"
                 ]
               }
             ]


### PR DESCRIPTION
## Summary
- expose all api-reference endpoint pages through the docs.json navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68add88a41c88333986d0916498d4adf