### PR TITLE
docs: add blocks API endpoint docs

### DIFF
--- a/api-reference/endpoint/etherscan-dailyavgblocksize.mdx
+++ b/api-reference/endpoint/etherscan-dailyavgblocksize.mdx
@@ -1,0 +1,78 @@
+---
+title: 'Get Daily Average Block Size'
+api: 'GET /v2/api'
+keywords: ['average block size', 'daily stats']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the daily average block size within a date range" pro={true} />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="stats">
+  Set to `stats` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="dailyavgblocksize">
+  Set to `dailyavgblocksize` for this endpoint.
+</ParamField>
+<ParamField query="startdate" type="string" initialValue="2019-02-01">
+  Starting date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="enddate" type="string" initialValue="2019-02-28">
+  Ending date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="sort" type="string" initialValue="asc">
+  Sort order, either `asc` or `desc`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+
+<RequestExample>
+https://api.etherscan.io/v2/api?chainid=1&module=stats&action=dailyavgblocksize&startdate=2019-02-01&enddate=2019-02-28&sort=asc&apikey=YourApiKeyToken
+</RequestExample>
+
+<ResponseField name="status" type="string">
+  `1` for success, `0` for errors.
+</ResponseField>
+<ResponseField name="message" type="string">
+  Description of the response status.
+</ResponseField>
+<ResponseField name="result" type="array">
+  <Expandable title="Daily average block size">
+    <ResponseField name="UTCDate" type="string">Date in UTC.</ResponseField>
+    <ResponseField name="unixTimeStamp" type="string">Unix timestamp.</ResponseField>
+    <ResponseField name="blockSize_bytes" type="integer">Average block size in bytes.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseExample title="Success">
+{
+  "status":"1",
+  "message":"OK",
+  "result":[
+    {
+      "UTCDate":"2019-02-01",
+      "unixTimeStamp":"1548979200",
+      "blockSize_bytes":20373
+    },
+    {
+      "UTCDate":"2019-02-28",
+      "unixTimeStamp":"1551312000",
+      "blockSize_bytes":25117
+    }
+  ]
+}
+</ResponseExample>
+
+<ResponseExample title="Error">
+{
+  "status":"0",
+  "message":"NOTOK",
+  "result":"Max rate limit reached"
+}
+</ResponseExample>
+

--- a/api-reference/endpoint/etherscan-dailyavgblocktime.mdx
+++ b/api-reference/endpoint/etherscan-dailyavgblocktime.mdx
@@ -1,0 +1,78 @@
+---
+title: 'Get Daily Average Block Time'
+api: 'GET /v2/api'
+keywords: ['average block time', 'daily stats']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the daily average time for a block to be mined" pro={true} />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="stats">
+  Set to `stats` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="dailyavgblocktime">
+  Set to `dailyavgblocktime` for this endpoint.
+</ParamField>
+<ParamField query="startdate" type="string" initialValue="2019-02-01">
+  Starting date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="enddate" type="string" initialValue="2019-02-28">
+  Ending date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="sort" type="string" initialValue="asc">
+  Sort order, either `asc` or `desc`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+
+<RequestExample>
+https://api.etherscan.io/v2/api?chainid=1&module=stats&action=dailyavgblocktime&startdate=2019-02-01&enddate=2019-02-28&sort=asc&apikey=YourApiKeyToken
+</RequestExample>
+
+<ResponseField name="status" type="string">
+  `1` for success, `0` for errors.
+</ResponseField>
+<ResponseField name="message" type="string">
+  Description of the response status.
+</ResponseField>
+<ResponseField name="result" type="array">
+  <Expandable title="Daily average block time">
+    <ResponseField name="UTCDate" type="string">Date in UTC.</ResponseField>
+    <ResponseField name="unixTimeStamp" type="string">Unix timestamp.</ResponseField>
+    <ResponseField name="blockTime_sec" type="string">Average block time in seconds.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseExample title="Success">
+{
+  "status":"1",
+  "message":"OK",
+  "result":[
+    {
+      "UTCDate":"2019-02-01",
+      "unixTimeStamp":"1548979200",
+      "blockTime_sec":"17.67"
+    },
+    {
+      "UTCDate":"2019-02-28",
+      "unixTimeStamp":"1551312000",
+      "blockTime_sec":"19.61"
+    }
+  ]
+}
+</ResponseExample>
+
+<ResponseExample title="Error">
+{
+  "status":"0",
+  "message":"NOTOK",
+  "result":"Max rate limit reached"
+}
+</ResponseExample>
+

--- a/api-reference/endpoint/etherscan-dailyblkcount.mdx
+++ b/api-reference/endpoint/etherscan-dailyblkcount.mdx
@@ -1,0 +1,81 @@
+---
+title: 'Get Daily Block Count and Rewards'
+api: 'GET /v2/api'
+keywords: ['daily block count', 'block rewards']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the number of blocks mined daily and the amount of block rewards" pro={true} />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="stats">
+  Set to `stats` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="dailyblkcount">
+  Set to `dailyblkcount` for this endpoint.
+</ParamField>
+<ParamField query="startdate" type="string" initialValue="2019-02-01">
+  Starting date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="enddate" type="string" initialValue="2019-02-28">
+  Ending date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="sort" type="string" initialValue="asc">
+  Sort order, either `asc` or `desc`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+
+<RequestExample>
+https://api.etherscan.io/v2/api?chainid=1&module=stats&action=dailyblkcount&startdate=2019-02-01&enddate=2019-02-28&sort=asc&apikey=YourApiKeyToken
+</RequestExample>
+
+<ResponseField name="status" type="string">
+  `1` for success, `0` for errors.
+</ResponseField>
+<ResponseField name="message" type="string">
+  Description of the response status.
+</ResponseField>
+<ResponseField name="result" type="array">
+  <Expandable title="Daily block count">
+    <ResponseField name="UTCDate" type="string">Date in UTC.</ResponseField>
+    <ResponseField name="unixTimeStamp" type="string">Unix timestamp.</ResponseField>
+    <ResponseField name="blockCount" type="integer">Number of blocks mined.</ResponseField>
+    <ResponseField name="blockRewards_Eth" type="string">Block rewards in Ether.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseExample title="Success">
+{
+  "status":"1",
+  "message":"OK",
+  "result":[
+    {
+      "UTCDate":"2019-02-01",
+      "unixTimeStamp":"1548979200",
+      "blockCount":4848,
+      "blockRewards_Eth":"14929.464690870590355682"
+    },
+    {
+      "UTCDate":"2019-02-28",
+      "unixTimeStamp":"1551312000",
+      "blockCount":4366,
+      "blockRewards_Eth":"12808.485512162356907132"
+    }
+  ]
+}
+</ResponseExample>
+
+<ResponseExample title="Error">
+{
+  "status":"0",
+  "message":"NOTOK",
+  "result":"Max rate limit reached"
+}
+</ResponseExample>
+

--- a/api-reference/endpoint/etherscan-dailyblockrewards.mdx
+++ b/api-reference/endpoint/etherscan-dailyblockrewards.mdx
@@ -1,0 +1,78 @@
+---
+title: 'Get Daily Block Rewards'
+api: 'GET /v2/api'
+keywords: ['daily block rewards', 'miner rewards']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the amount of block rewards distributed to miners daily" pro={true} />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="stats">
+  Set to `stats` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="dailyblockrewards">
+  Set to `dailyblockrewards` for this endpoint.
+</ParamField>
+<ParamField query="startdate" type="string" initialValue="2019-02-01">
+  Starting date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="enddate" type="string" initialValue="2019-02-28">
+  Ending date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="sort" type="string" initialValue="asc">
+  Sort order, either `asc` or `desc`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+
+<RequestExample>
+https://api.etherscan.io/v2/api?chainid=1&module=stats&action=dailyblockrewards&startdate=2019-02-01&enddate=2019-02-28&sort=asc&apikey=YourApiKeyToken
+</RequestExample>
+
+<ResponseField name="status" type="string">
+  `1` for success, `0` for errors.
+</ResponseField>
+<ResponseField name="message" type="string">
+  Description of the response status.
+</ResponseField>
+<ResponseField name="result" type="array">
+  <Expandable title="Daily block rewards">
+    <ResponseField name="UTCDate" type="string">Date in UTC.</ResponseField>
+    <ResponseField name="unixTimeStamp" type="string">Unix timestamp.</ResponseField>
+    <ResponseField name="blockRewards_Eth" type="string">Block rewards in Ether.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseExample title="Success">
+{
+  "status":"1",
+  "message":"OK",
+  "result":[
+    {
+      "UTCDate":"2019-02-01",
+      "unixTimeStamp":"1548979200",
+      "blockRewards_Eth":"15300.65625"
+    },
+    {
+      "UTCDate":"2019-02-28",
+      "unixTimeStamp":"1551312000",
+      "blockRewards_Eth":"12954.84375"
+    }
+  ]
+}
+</ResponseExample>
+
+<ResponseExample title="Error">
+{
+  "status":"0",
+  "message":"NOTOK",
+  "result":"Max rate limit reached"
+}
+</ResponseExample>
+

--- a/api-reference/endpoint/etherscan-dailyuncleblkcount.mdx
+++ b/api-reference/endpoint/etherscan-dailyuncleblkcount.mdx
@@ -1,0 +1,81 @@
+---
+title: 'Get Daily Uncle Block Count and Rewards'
+api: 'GET /v2/api'
+keywords: ['daily uncle block count', 'uncle rewards']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the number of uncle blocks mined daily and the uncle block rewards" pro={true} />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="stats">
+  Set to `stats` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="dailyuncleblkcount">
+  Set to `dailyuncleblkcount` for this endpoint.
+</ParamField>
+<ParamField query="startdate" type="string" initialValue="2019-02-01">
+  Starting date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="enddate" type="string" initialValue="2019-02-28">
+  Ending date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="sort" type="string" initialValue="asc">
+  Sort order, either `asc` or `desc`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+
+<RequestExample>
+https://api.etherscan.io/v2/api?chainid=1&module=stats&action=dailyuncleblkcount&startdate=2019-02-01&enddate=2019-02-28&sort=asc&apikey=YourApiKeyToken
+</RequestExample>
+
+<ResponseField name="status" type="string">
+  `1` for success, `0` for errors.
+</ResponseField>
+<ResponseField name="message" type="string">
+  Description of the response status.
+</ResponseField>
+<ResponseField name="result" type="array">
+  <Expandable title="Daily uncle block count">
+    <ResponseField name="UTCDate" type="string">Date in UTC.</ResponseField>
+    <ResponseField name="unixTimeStamp" type="string">Unix timestamp.</ResponseField>
+    <ResponseField name="uncleBlockCount" type="integer">Number of uncle blocks mined.</ResponseField>
+    <ResponseField name="uncleBlockRewards_Eth" type="string">Uncle block rewards in Ether.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseExample title="Success">
+{
+  "status":"1",
+  "message":"OK",
+  "result":[
+    {
+      "UTCDate":"2019-02-01",
+      "unixTimeStamp":"1548979200",
+      "uncleBlockCount":287,
+      "uncleBlockRewards_Eth":"729.75"
+    },
+    {
+      "UTCDate":"2019-02-28",
+      "unixTimeStamp":"1551312000",
+      "uncleBlockCount":288,
+      "uncleBlockRewards_Eth":"691.5"
+    }
+  ]
+}
+</ResponseExample>
+
+<ResponseExample title="Error">
+{
+  "status":"0",
+  "message":"NOTOK",
+  "result":"Max rate limit reached"
+}
+</ResponseExample>
+

--- a/api-reference/endpoint/etherscan-getblockcountdown.mdx
+++ b/api-reference/endpoint/etherscan-getblockcountdown.mdx
@@ -1,0 +1,67 @@
+---
+title: 'Get Estimated Block Countdown by Block Number'
+api: 'GET /v2/api'
+keywords: ['block countdown', 'estimated time']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the estimated time remaining until a block is mined" />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="block">
+  Set to `block` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="getblockcountdown">
+  Set to `getblockcountdown` for this endpoint.
+</ParamField>
+<ParamField query="blockno" type="integer" initialValue="16701588">
+  Block number to estimate time remaining for.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+
+<RequestExample>
+https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblockcountdown&blockno=16701588&apikey=YourApiKeyToken
+</RequestExample>
+
+<ResponseField name="status" type="string">
+  `1` for success, `0` for errors.
+</ResponseField>
+<ResponseField name="message" type="string">
+  Description of the response status.
+</ResponseField>
+<ResponseField name="result" type="object">
+  <Expandable title="Block countdown">
+    <ResponseField name="CurrentBlock" type="string">Current block number.</ResponseField>
+    <ResponseField name="CountdownBlock" type="string">Target block number.</ResponseField>
+    <ResponseField name="RemainingBlock" type="string">Blocks remaining.</ResponseField>
+    <ResponseField name="EstimateTimeInSec" type="string">Estimated time remaining in seconds.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseExample title="Success">
+{
+  "status":"1",
+  "message":"OK",
+  "result":{
+    "CurrentBlock":"12715477",
+    "CountdownBlock":"16701588",
+    "RemainingBlock":"3986111",
+    "EstimateTimeInSec":"52616680.2"
+  }
+}
+</ResponseExample>
+
+<ResponseExample title="Error">
+{
+  "status":"0",
+  "message":"NOTOK",
+  "result":"Max rate limit reached"
+}
+</ResponseExample>
+

--- a/api-reference/endpoint/etherscan-getblocknobytime.mdx
+++ b/api-reference/endpoint/etherscan-getblocknobytime.mdx
@@ -1,0 +1,60 @@
+---
+title: 'Get Block Number by Timestamp'
+api: 'GET /v2/api'
+keywords: ['block number', 'timestamp']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the block number mined at a given timestamp" />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="block">
+  Set to `block` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="getblocknobytime">
+  Set to `getblocknobytime` for this endpoint.
+</ParamField>
+<ParamField query="timestamp" type="integer" initialValue="1578638524">
+  Unix timestamp in seconds.
+</ParamField>
+<ParamField query="closest" type="string" initialValue="before">
+  Closest available block to the provided timestamp, either `before` or `after`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+
+<RequestExample>
+https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&timestamp=1578638524&closest=before&apikey=YourApiKeyToken
+</RequestExample>
+
+<ResponseField name="status" type="string">
+  `1` for success, `0` for errors.
+</ResponseField>
+<ResponseField name="message" type="string">
+  Description of the response status.
+</ResponseField>
+<ResponseField name="result" type="string">
+  Block number mined at the provided timestamp.
+</ResponseField>
+
+<ResponseExample title="Success">
+{
+  "status":"1",
+  "message":"OK",
+  "result":"12712551"
+}
+</ResponseExample>
+
+<ResponseExample title="Error">
+{
+  "status":"0",
+  "message":"NOTOK",
+  "result":"Max rate limit reached"
+}
+</ResponseExample>
+

--- a/api-reference/endpoint/etherscan-getblockreward.mdx
+++ b/api-reference/endpoint/etherscan-getblockreward.mdx
@@ -1,0 +1,88 @@
+---
+title: 'Get Block and Uncle Rewards by Block Number'
+api: 'GET /v2/api'
+keywords: ['block reward', 'uncle block reward']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the block reward and uncle rewards for a block" />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="block">
+  Set to `block` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="getblockreward">
+  Set to `getblockreward` for this endpoint.
+</ParamField>
+<ParamField query="blockno" type="integer" initialValue="2165403">
+  Block number to check rewards for.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+
+<RequestExample>
+https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblockreward&blockno=2165403&apikey=YourApiKeyToken
+</RequestExample>
+
+<ResponseField name="status" type="string">
+  `1` for success, `0` for errors.
+</ResponseField>
+<ResponseField name="message" type="string">
+  Description of the response status.
+</ResponseField>
+<ResponseField name="result" type="object">
+  <Expandable title="Block rewards">
+    <ResponseField name="blockNumber" type="string">Block number.</ResponseField>
+    <ResponseField name="timeStamp" type="string">Block time in Unix.</ResponseField>
+    <ResponseField name="blockMiner" type="string">Miner address.</ResponseField>
+    <ResponseField name="blockReward" type="string">Block reward in wei.</ResponseField>
+    <ResponseField name="uncles" type="array">
+      <Expandable title="Uncle">
+        <ResponseField name="miner" type="string">Uncle miner address.</ResponseField>
+        <ResponseField name="unclePosition" type="string">Position in the block.</ResponseField>
+        <ResponseField name="blockreward" type="string">Uncle block reward in wei.</ResponseField>
+      </Expandable>
+    </ResponseField>
+    <ResponseField name="uncleInclusionReward" type="string">Uncle inclusion reward in wei.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<ResponseExample title="Success">
+{
+  "status":"1",
+  "message":"OK",
+  "result":{
+    "blockNumber":"2165403",
+    "timeStamp":"1472533979",
+    "blockMiner":"0x13a06d3dfe21e0db5c016c03ea7d2509f7f8d1e3",
+    "blockReward":"5314181600000000000",
+    "uncles":[
+      {
+        "miner":"0xbcdfc35b86bedf72f0cda046a3c16829a2ef41d1",
+        "unclePosition":"0",
+        "blockreward":"3750000000000000000"
+      },
+      {
+        "miner":"0x0d0c9855c722ff0c78f21e43aa275a5b8ea60dce",
+        "unclePosition":"1",
+        "blockreward":"3750000000000000000"
+      }
+    ],
+    "uncleInclusionReward":"312500000000000000"
+  }
+}
+</ResponseExample>
+
+<ResponseExample title="Error">
+{
+  "status":"0",
+  "message":"NOTOK",
+  "result":"Max rate limit reached"
+}
+</ResponseExample>
+

--- a/docs.json
+++ b/docs.json
@@ -52,6 +52,19 @@
                   "api-reference/endpoint/etherscan-txlistinternal",
                   "api-reference/endpoint/etherscan-txsbeaconwithdrawal"
                 ]
+              },
+              {
+                "group": "Blocks",
+                "pages": [
+                  "api-reference/endpoint/etherscan-getblockreward",
+                  "api-reference/endpoint/etherscan-getblockcountdown",
+                  "api-reference/endpoint/etherscan-getblocknobytime",
+                  "api-reference/endpoint/etherscan-dailyavgblocksize",
+                  "api-reference/endpoint/etherscan-dailyblkcount",
+                  "api-reference/endpoint/etherscan-dailyblockrewards",
+                  "api-reference/endpoint/etherscan-dailyavgblocktime",
+                  "api-reference/endpoint/etherscan-dailyuncleblkcount"
+                ]
               }
             ]
           },


### PR DESCRIPTION
## Summary
- document block reward and block lookup endpoints
- cover daily block statistics (avg size, counts, rewards, times, uncles)
- add Blocks group to API reference navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b03990bdf0833390bc1b955e3ffb23