### PR TITLE
docs: add blocks API endpoint docs

### DIFF
--- a/api-reference/endpoint/etherscan-dailyavgblocksize.mdx
+++ b/api-reference/endpoint/etherscan-dailyavgblocksize.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Get Daily Average Block Size'
+api: 'GET /v2/api'
+keywords: ['average block size', 'daily stats']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the daily average block size within a date range" pro={true} />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="stats">
+  Set to `stats` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="dailyavgblocksize">
+  Set to `dailyavgblocksize` for this endpoint.
+</ParamField>
+<ParamField query="startdate" type="string" initialValue="2019-02-01">
+  Starting date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="enddate" type="string" initialValue="2019-02-28">
+  Ending date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="sort" type="string" initialValue="asc">
+  Sort order, either `asc` or `desc`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+

--- a/api-reference/endpoint/etherscan-dailyavgblocktime.mdx
+++ b/api-reference/endpoint/etherscan-dailyavgblocktime.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Get Daily Average Block Time'
+api: 'GET /v2/api'
+keywords: ['average block time', 'daily stats']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the daily average time for a block to be mined" pro={true} />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="stats">
+  Set to `stats` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="dailyavgblocktime">
+  Set to `dailyavgblocktime` for this endpoint.
+</ParamField>
+<ParamField query="startdate" type="string" initialValue="2019-02-01">
+  Starting date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="enddate" type="string" initialValue="2019-02-28">
+  Ending date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="sort" type="string" initialValue="asc">
+  Sort order, either `asc` or `desc`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+

--- a/api-reference/endpoint/etherscan-dailyblkcount.mdx
+++ b/api-reference/endpoint/etherscan-dailyblkcount.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Get Daily Block Count and Rewards'
+api: 'GET /v2/api'
+keywords: ['daily block count', 'block rewards']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the number of blocks mined daily and the amount of block rewards" pro={true} />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="stats">
+  Set to `stats` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="dailyblkcount">
+  Set to `dailyblkcount` for this endpoint.
+</ParamField>
+<ParamField query="startdate" type="string" initialValue="2019-02-01">
+  Starting date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="enddate" type="string" initialValue="2019-02-28">
+  Ending date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="sort" type="string" initialValue="asc">
+  Sort order, either `asc` or `desc`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+

--- a/api-reference/endpoint/etherscan-dailyblockrewards.mdx
+++ b/api-reference/endpoint/etherscan-dailyblockrewards.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Get Daily Block Rewards'
+api: 'GET /v2/api'
+keywords: ['daily block rewards', 'miner rewards']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the amount of block rewards distributed to miners daily" pro={true} />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="stats">
+  Set to `stats` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="dailyblockrewards">
+  Set to `dailyblockrewards` for this endpoint.
+</ParamField>
+<ParamField query="startdate" type="string" initialValue="2019-02-01">
+  Starting date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="enddate" type="string" initialValue="2019-02-28">
+  Ending date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="sort" type="string" initialValue="asc">
+  Sort order, either `asc` or `desc`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+

--- a/api-reference/endpoint/etherscan-dailyuncleblkcount.mdx
+++ b/api-reference/endpoint/etherscan-dailyuncleblkcount.mdx
@@ -1,0 +1,33 @@
+---
+title: 'Get Daily Uncle Block Count and Rewards'
+api: 'GET /v2/api'
+keywords: ['daily uncle block count', 'uncle rewards']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the number of uncle blocks mined daily and the uncle block rewards" pro={true} />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="stats">
+  Set to `stats` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="dailyuncleblkcount">
+  Set to `dailyuncleblkcount` for this endpoint.
+</ParamField>
+<ParamField query="startdate" type="string" initialValue="2019-02-01">
+  Starting date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="enddate" type="string" initialValue="2019-02-28">
+  Ending date in `yyyy-MM-dd` format.
+</ParamField>
+<ParamField query="sort" type="string" initialValue="asc">
+  Sort order, either `asc` or `desc`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+

--- a/api-reference/endpoint/etherscan-getblockcountdown.mdx
+++ b/api-reference/endpoint/etherscan-getblockcountdown.mdx
@@ -1,0 +1,27 @@
+---
+title: 'Get Estimated Block Countdown by Block Number'
+api: 'GET /v2/api'
+keywords: ['block countdown', 'estimated time']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the estimated time remaining until a block is mined" />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="block">
+  Set to `block` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="getblockcountdown">
+  Set to `getblockcountdown` for this endpoint.
+</ParamField>
+<ParamField query="blockno" type="integer" initialValue="16701588">
+  Block number to estimate time remaining for.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+

--- a/api-reference/endpoint/etherscan-getblocknobytime.mdx
+++ b/api-reference/endpoint/etherscan-getblocknobytime.mdx
@@ -1,0 +1,30 @@
+---
+title: 'Get Block Number by Timestamp'
+api: 'GET /v2/api'
+keywords: ['block number', 'timestamp']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the block number mined at a given timestamp" />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="block">
+  Set to `block` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="getblocknobytime">
+  Set to `getblocknobytime` for this endpoint.
+</ParamField>
+<ParamField query="timestamp" type="integer" initialValue="1578638524">
+  Unix timestamp in seconds.
+</ParamField>
+<ParamField query="closest" type="string" initialValue="before">
+  Closest available block to the provided timestamp, either `before` or `after`.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+

--- a/api-reference/endpoint/etherscan-getblockreward.mdx
+++ b/api-reference/endpoint/etherscan-getblockreward.mdx
@@ -1,0 +1,27 @@
+---
+title: 'Get Block and Uncle Rewards by Block Number'
+api: 'GET /v2/api'
+keywords: ['block reward', 'uncle block reward']
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the block reward and uncle rewards for a block" />
+
+<ParamField query="chainid" type="string" initialValue="1">
+  Chain ID you query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+</ParamField>
+<ParamField query="module" type="string" initialValue="block">
+  Set to `block` for this endpoint.
+</ParamField>
+<ParamField query="action" type="string" initialValue="getblockreward">
+  Set to `getblockreward` for this endpoint.
+</ParamField>
+<ParamField query="blockno" type="integer" initialValue="2165403">
+  Block number to check rewards for.
+</ParamField>
+<ParamField query="apikey" type="string">
+  Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+</ParamField>
+

--- a/docs.json
+++ b/docs.json
@@ -52,6 +52,19 @@
                   "api-reference/endpoint/etherscan-txlistinternal",
                   "api-reference/endpoint/etherscan-txsbeaconwithdrawal"
                 ]
+              },
+              {
+                "group": "Blocks",
+                "pages": [
+                  "api-reference/endpoint/etherscan-getblockreward",
+                  "api-reference/endpoint/etherscan-getblockcountdown",
+                  "api-reference/endpoint/etherscan-getblocknobytime",
+                  "api-reference/endpoint/etherscan-dailyavgblocksize",
+                  "api-reference/endpoint/etherscan-dailyblkcount",
+                  "api-reference/endpoint/etherscan-dailyblockrewards",
+                  "api-reference/endpoint/etherscan-dailyavgblocktime",
+                  "api-reference/endpoint/etherscan-dailyuncleblkcount"
+                ]
               }
             ]
           },


### PR DESCRIPTION
## Summary
- document block reward and block lookup endpoints
- cover daily block statistics (avg size, counts, rewards, times, uncles)
- add Blocks group to API reference navigation
- remove request, response field, and response example sections from block docs for consistency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b03990bdf0833390bc1b955e3ffb23