### PR TITLE
docs: add logs, stats, transaction, and token endpoint docs

### DIFF
--- a/api-reference/endpoint/addresstokenbalance.mdx
+++ b/api-reference/endpoint/addresstokenbalance.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Address ERC20 Token Holding"
+api: "GET /v2/api"
+keywords: ["address token balance", "erc20 holdings"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the ERC-20 tokens and amounts held by an address" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="account">
+    Set to `account` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="addresstokenbalance">
+    Set to `addresstokenbalance` for this endpoint.
+  </ParamField>
+  <ParamField query="address" type="string" initialValue="0x983e3660c0bE01991785F80f266A84B911ab59b0">
+    Address to check for token holdings.
+  </ParamField>
+  <ParamField query="page" type="integer" initialValue="1">
+    Page number for pagination.
+  </ParamField>
+  <ParamField query="offset" type="integer" initialValue="100">
+    Number of records per page.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/addresstokennftbalance.mdx
+++ b/api-reference/endpoint/addresstokennftbalance.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Address ERC721 Token Holding"
+api: "GET /v2/api"
+keywords: ["address nft balance", "erc721 holdings"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the ERC-721 tokens and amounts held by an address" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="account">
+    Set to `account` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="addresstokennftbalance">
+    Set to `addresstokennftbalance` for this endpoint.
+  </ParamField>
+  <ParamField query="address" type="string" initialValue="0x6b52e83941eb10f9c613c395a834457559a80114">
+    Address to check for NFT holdings.
+  </ParamField>
+  <ParamField query="page" type="integer" initialValue="1">
+    Page number for pagination.
+  </ParamField>
+  <ParamField query="offset" type="integer" initialValue="100">
+    Number of records per page.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/addresstokennftinventory.mdx
+++ b/api-reference/endpoint/addresstokennftinventory.mdx
@@ -1,0 +1,35 @@
+---
+title: "Get Address ERC721 Token Inventory by Contract"
+api: "GET /v2/api"
+keywords: ["address nft inventory", "erc721 inventory"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the ERC-721 token inventory of an address filtered by contract" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="account">
+    Set to `account` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="addresstokennftinventory">
+    Set to `addresstokennftinventory` for this endpoint.
+  </ParamField>
+  <ParamField query="address" type="string" initialValue="0x123432244443b54409430979df8333f9308a6040">
+    Address to check for inventory.
+  </ParamField>
+  <ParamField query="contractaddress" type="string" initialValue="0xed5af388653567af2f388e6224dc7c4b3241c544">
+    ERC-721 token contract address to filter by.
+  </ParamField>
+  <ParamField query="page" type="integer" initialValue="1">
+    Page number for pagination.
+  </ParamField>
+  <ParamField query="offset" type="integer" initialValue="100">
+    Number of records per page. Limited to 1000 records per query; use the `page` parameter for subsequent records.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/chainsize.mdx
+++ b/api-reference/endpoint/chainsize.mdx
@@ -1,0 +1,38 @@
+---
+title: "Get Ethereum Nodes Size"
+api: "GET /v2/api"
+keywords: ["chain size", "node size"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the size of the Ethereum blockchain in bytes over a date range" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="chainsize">
+    Set to `chainsize` for this endpoint.
+  </ParamField>
+  <ParamField query="startdate" type="string" initialValue="2019-02-01">
+    Starting date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="enddate" type="string" initialValue="2019-02-28">
+    Ending date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="clienttype" type="string" initialValue="geth">
+    Node client to query, either `geth` or `parity`.
+  </ParamField>
+  <ParamField query="syncmode" type="string" initialValue="default">
+    Node type to run, either `default` or `archive`.
+  </ParamField>
+  <ParamField query="sort" type="string" initialValue="asc">
+    Sort order either `desc` for the latest results first or `asc` for the oldest results first.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/dailyavghashrate.mdx
+++ b/api-reference/endpoint/dailyavghashrate.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Daily Average Network Hash Rate"
+api: "GET /v2/api"
+keywords: ["average hash rate", "daily hash rate"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the historical measure of processing power of the Ethereum network" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="dailyavghashrate">
+    Set to `dailyavghashrate` for this endpoint.
+  </ParamField>
+  <ParamField query="startdate" type="string" initialValue="2019-02-01">
+    Starting date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="enddate" type="string" initialValue="2019-02-28">
+    Ending date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="sort" type="string" initialValue="asc">
+    Sort order either `desc` for the latest results first or `asc` for the oldest results first.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/dailyavgnetdifficulty.mdx
+++ b/api-reference/endpoint/dailyavgnetdifficulty.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Daily Average Network Difficulty"
+api: "GET /v2/api"
+keywords: ["network difficulty", "daily difficulty"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the historical mining difficulty of the Ethereum network" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="dailyavgnetdifficulty">
+    Set to `dailyavgnetdifficulty` for this endpoint.
+  </ParamField>
+  <ParamField query="startdate" type="string" initialValue="2019-02-01">
+    Starting date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="enddate" type="string" initialValue="2019-02-28">
+    Ending date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="sort" type="string" initialValue="asc">
+    Sort order either `desc` for the latest results first or `asc` for the oldest results first.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/dailynetutilization.mdx
+++ b/api-reference/endpoint/dailynetutilization.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Daily Network Utilization"
+api: "GET /v2/api"
+keywords: ["network utilization", "daily utilization"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the daily average gas used over gas limit in percentage" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="dailynetutilization">
+    Set to `dailynetutilization` for this endpoint.
+  </ParamField>
+  <ParamField query="startdate" type="string" initialValue="2019-02-01">
+    Starting date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="enddate" type="string" initialValue="2019-02-28">
+    Ending date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="sort" type="string" initialValue="asc">
+    Sort order either `desc` for the latest results first or `asc` for the oldest results first.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/dailynewaddress.mdx
+++ b/api-reference/endpoint/dailynewaddress.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Daily New Address Count"
+api: "GET /v2/api"
+keywords: ["new address count", "daily new address"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the number of new Ethereum addresses created per day" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="dailynewaddress">
+    Set to `dailynewaddress` for this endpoint.
+  </ParamField>
+  <ParamField query="startdate" type="string" initialValue="2019-02-01">
+    Starting date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="enddate" type="string" initialValue="2019-02-28">
+    Ending date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="sort" type="string" initialValue="asc">
+    Sort order either `desc` for the latest results first or `asc` for the oldest results first.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/dailytx.mdx
+++ b/api-reference/endpoint/dailytx.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Daily Transaction Count"
+api: "GET /v2/api"
+keywords: ["daily transaction count", "dailytx"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the number of transactions performed per day" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="dailytx">
+    Set to `dailytx` for this endpoint.
+  </ParamField>
+  <ParamField query="startdate" type="string" initialValue="2019-02-01">
+    Starting date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="enddate" type="string" initialValue="2019-02-28">
+    Ending date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="sort" type="string" initialValue="asc">
+    Sort order either `desc` for the latest results first or `asc` for the oldest results first.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/dailytxnfee.mdx
+++ b/api-reference/endpoint/dailytxnfee.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Daily Network Transaction Fee"
+api: "GET /v2/api"
+keywords: ["daily transaction fee", "miner fees"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the amount of transaction fees paid to miners per day" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="dailytxnfee">
+    Set to `dailytxnfee` for this endpoint.
+  </ParamField>
+  <ParamField query="startdate" type="string" initialValue="2019-02-01">
+    Starting date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="enddate" type="string" initialValue="2019-02-28">
+    Ending date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="sort" type="string" initialValue="asc">
+    Sort order either `desc` for the latest results first or `asc` for the oldest results first.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/ethdailyprice.mdx
+++ b/api-reference/endpoint/ethdailyprice.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Ether Historical Price"
+api: "GET /v2/api"
+keywords: ["eth historical price", "ethdailyprice"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the historical price of 1 ETH" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="ethdailyprice">
+    Set to `ethdailyprice` for this endpoint.
+  </ParamField>
+  <ParamField query="startdate" type="string" initialValue="2019-02-01">
+    Starting date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="enddate" type="string" initialValue="2019-02-28">
+    Ending date in `yyyy-MM-dd` format.
+  </ParamField>
+  <ParamField query="sort" type="string" initialValue="asc">
+    Sort order either `desc` for the latest results first or `asc` for the oldest results first.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/ethprice.mdx
+++ b/api-reference/endpoint/ethprice.mdx
@@ -1,0 +1,23 @@
+---
+title: "Get Ether Last Price"
+api: "GET /v2/api"
+keywords: ["eth price", "latest price"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the latest price of 1 ETH" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="ethprice">
+    Set to `ethprice` for this endpoint.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/ethsupply.mdx
+++ b/api-reference/endpoint/ethsupply.mdx
@@ -1,0 +1,23 @@
+---
+title: "Get Total Supply of Ether"
+api: "GET /v2/api"
+keywords: ["eth supply", "circulating ether"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the current amount of Ether in circulation excluding ETH2 staking rewards and EIP1559 burnt fees" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="ethsupply">
+    Set to `ethsupply` for this endpoint.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/ethsupply2.mdx
+++ b/api-reference/endpoint/ethsupply2.mdx
@@ -1,0 +1,23 @@
+---
+title: "Get Total Supply of Ether 2"
+api: "GET /v2/api"
+keywords: ["eth supply", "ethsupply2"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns Ether supply details including staking rewards, burnt fees, and withdrawn amounts" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="ethsupply2">
+    Set to `ethsupply2` for this endpoint.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/getlogs-address-topics.mdx
+++ b/api-reference/endpoint/getlogs-address-topics.mdx
@@ -1,0 +1,47 @@
+---
+title: "Get Event Logs by Address and Topics"
+api: "GET /v2/api"
+keywords: ["event logs", "address topics"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns event logs from an address filtered by topics and block range" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="logs">
+    Set to `logs` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="getLogs">
+    Set to `getLogs` for this endpoint.
+  </ParamField>
+  <ParamField query="fromBlock" type="integer" initialValue="15073139">
+    Starting block number to search from.
+  </ParamField>
+  <ParamField query="toBlock" type="integer" initialValue="15074139">
+    Ending block number to search to.
+  </ParamField>
+  <ParamField query="address" type="string" initialValue="0x59728544b08ab483533076417fbbb2fd0b17ce3a">
+    Address to check for logs.
+  </ParamField>
+  <ParamField query="topic0" type="string" initialValue="0x27c4f0403323142b599832f26acd21c74a9e5b809f2215726e244a4ac588cd7d">
+    First topic to filter by, such as an event signature.
+  </ParamField>
+  <ParamField query="topic0_1_opr" type="string" initialValue="and">
+    Topic operator between `topic0` and `topic1`, either `and` or `or`.
+  </ParamField>
+  <ParamField query="topic1" type="string" initialValue="0x00000000000000000000000023581767a106ae21c074b2276d25e5c3e136a68b">
+    Second topic to filter by.
+  </ParamField>
+  <ParamField query="page" type="integer" initialValue="1">
+    Page number for pagination.
+  </ParamField>
+  <ParamField query="offset" type="integer" initialValue="1000">
+    Number of records per page. Limited to 1000 records per query; use the `page` parameter for subsequent records.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/getlogs-topics.mdx
+++ b/api-reference/endpoint/getlogs-topics.mdx
@@ -1,0 +1,65 @@
+---
+title: "Get Event Logs by Topics"
+api: "GET /v2/api"
+keywords: ["event logs", "topics"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns event logs in a block range filtered by topics" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="logs">
+    Set to `logs` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="getLogs">
+    Set to `getLogs` for this endpoint.
+  </ParamField>
+  <ParamField query="fromBlock" type="integer" initialValue="12878196">
+    Starting block number to search from.
+  </ParamField>
+  <ParamField query="toBlock" type="integer" initialValue="12879196">
+    Ending block number to search to.
+  </ParamField>
+  <ParamField query="topic0" type="string" initialValue="0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef">
+    First topic to filter by, such as an event signature.
+  </ParamField>
+  <ParamField query="topic0_1_opr" type="string" initialValue="and">
+    Topic operator between `topic0` and `topic1`, either `and` or `or`.
+  </ParamField>
+  <ParamField query="topic1" type="string" initialValue="0x0000000000000000000000000000000000000000000000000000000000000000">
+    Second topic to filter by.
+  </ParamField>
+  <ParamField query="topic1_2_opr" type="string" initialValue="and">
+    Topic operator between `topic1` and `topic2`, either `and` or `or`.
+  </ParamField>
+  <ParamField query="topic2" type="string" initialValue="0x000000000000000000000000c45a4b3b698f21f88687548e7f5a80df8b99d93d">
+    Third topic to filter by.
+  </ParamField>
+  <ParamField query="topic2_3_opr" type="string" initialValue="and">
+    Topic operator between `topic2` and `topic3`, either `and` or `or`.
+  </ParamField>
+  <ParamField query="topic3" type="string" initialValue="0x00000000000000000000000000000000000000000000000000000000000000b5">
+    Fourth topic to filter by.
+  </ParamField>
+  <ParamField query="topic0_2_opr" type="string" initialValue="and">
+    Topic operator between `topic0` and `topic2`, either `and` or `or`.
+  </ParamField>
+  <ParamField query="topic0_3_opr" type="string" initialValue="and">
+    Topic operator between `topic0` and `topic3`, either `and` or `or`.
+  </ParamField>
+  <ParamField query="topic1_3_opr" type="string" initialValue="and">
+    Topic operator between `topic1` and `topic3`, either `and` or `or`.
+  </ParamField>
+  <ParamField query="page" type="integer" initialValue="1">
+    Page number for pagination.
+  </ParamField>
+  <ParamField query="offset" type="integer" initialValue="1000">
+    Number of records per page. Limited to 1000 records per query; use the `page` parameter for subsequent records.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/getlogs.mdx
+++ b/api-reference/endpoint/getlogs.mdx
@@ -1,0 +1,38 @@
+---
+title: "Get Event Logs by Address"
+api: "GET /v2/api"
+keywords: ["event logs", "address logs"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns event logs from an address with optional block range filters" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="logs">
+    Set to `logs` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="getLogs">
+    Set to `getLogs` for this endpoint.
+  </ParamField>
+  <ParamField query="address" type="string" initialValue="0xbd3531da5cf5857e7cfaa92426877b022e612cf8">
+    Address to check for logs.
+  </ParamField>
+  <ParamField query="fromBlock" type="integer" initialValue="12878196">
+    Starting block number to search from.
+  </ParamField>
+  <ParamField query="toBlock" type="integer" initialValue="12878196">
+    Ending block number to search to.
+  </ParamField>
+  <ParamField query="page" type="integer" initialValue="1">
+    Page number for pagination.
+  </ParamField>
+  <ParamField query="offset" type="integer" initialValue="1000">
+    Number of records per page. Limited to 1000 records per query; use the `page` parameter for subsequent records.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/getstatus.mdx
+++ b/api-reference/endpoint/getstatus.mdx
@@ -1,0 +1,26 @@
+---
+title: "Check Contract Execution Status"
+api: "GET /v2/api"
+keywords: ["contract execution status", "getstatus"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the status code of a contract execution" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="transaction">
+    Set to `transaction` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="getstatus">
+    Set to `getstatus` for this endpoint.
+  </ParamField>
+  <ParamField query="txhash" type="string" initialValue="0x15f8e5ea1079d9a0bb04a4c58ae5fe7654b5b2b4463375ff7ffb490aa0032f3a">
+    Transaction hash to check the execution status.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/gettxreceiptstatus.mdx
+++ b/api-reference/endpoint/gettxreceiptstatus.mdx
@@ -1,0 +1,26 @@
+---
+title: "Check Transaction Receipt Status"
+api: "GET /v2/api"
+keywords: ["transaction receipt status", "gettxreceiptstatus"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the status code of a transaction execution" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="transaction">
+    Set to `transaction` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="gettxreceiptstatus">
+    Set to `gettxreceiptstatus` for this endpoint.
+  </ParamField>
+  <ParamField query="txhash" type="string" initialValue="0x513c1ba0bebf66436b5fed86ab668452b7805593c05073eb2d51d3a52f480a76">
+    Transaction hash to check the receipt status.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/nodecount.mdx
+++ b/api-reference/endpoint/nodecount.mdx
@@ -1,0 +1,23 @@
+---
+title: "Get Total Nodes Count"
+api: "GET /v2/api"
+keywords: ["node count", "total nodes"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the total number of discoverable Ethereum nodes" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="nodecount">
+    Set to `nodecount` for this endpoint.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/tokenbalance.mdx
+++ b/api-reference/endpoint/tokenbalance.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get ERC20-Token Account Balance for TokenContractAddress"
+api: "GET /v2/api"
+keywords: ["token balance", "erc20 balance"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the current balance of an ERC-20 token for an address" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="account">
+    Set to `account` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="tokenbalance">
+    Set to `tokenbalance` for this endpoint.
+  </ParamField>
+  <ParamField query="contractaddress" type="string" initialValue="0x57d90b64a1a57749b0f932f1a3395792e12e7055">
+    Contract address of the ERC-20 token.
+  </ParamField>
+  <ParamField query="address" type="string" initialValue="0xe04f27eb70e025b78871a2ad7eabe85e61212761">
+    Address to check for token balance.
+  </ParamField>
+  <ParamField query="tag" type="string" initialValue="latest">
+    Use `latest` for the last block number of the chain.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/tokenbalancehistory.mdx
+++ b/api-reference/endpoint/tokenbalancehistory.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Historical ERC20-Token Account Balance by BlockNo"
+api: "GET /v2/api"
+keywords: ["token balance history", "erc20 balance history"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the balance of an ERC-20 token for an address at a specific block" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="account">
+    Set to `account` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="tokenbalancehistory">
+    Set to `tokenbalancehistory` for this endpoint.
+  </ParamField>
+  <ParamField query="contractaddress" type="string" initialValue="0x57d90b64a1a57749b0f932f1a3395792e12e7055">
+    Contract address of the ERC-20 token.
+  </ParamField>
+  <ParamField query="address" type="string" initialValue="0xe04f27eb70e025b78871a2ad7eabe85e61212761">
+    Address to check for balance.
+  </ParamField>
+  <ParamField query="blockno" type="integer" initialValue="8000000">
+    Block number to check balance for.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/tokenholdercount.mdx
+++ b/api-reference/endpoint/tokenholdercount.mdx
@@ -1,0 +1,26 @@
+---
+title: "Get Token Holder Count by Contract Address"
+api: "GET /v2/api"
+keywords: ["token holder count", "erc20 holder count"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns a simple count of ERC20 token holders" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="token">
+    Set to `token` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="tokenholdercount">
+    Set to `tokenholdercount` for this endpoint.
+  </ParamField>
+  <ParamField query="contractaddress" type="string" initialValue="0xaaaebe6fe48e54f431b0c390cfaf0b017d09d42d">
+    Contract address of the ERC-20 token.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/tokenholderlist.mdx
+++ b/api-reference/endpoint/tokenholderlist.mdx
@@ -1,0 +1,32 @@
+---
+title: "Get Token Holder List by Contract Address"
+api: "GET /v2/api"
+keywords: ["token holder list", "erc20 holders"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the current ERC20 token holders and quantities" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="token">
+    Set to `token` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="tokenholderlist">
+    Set to `tokenholderlist` for this endpoint.
+  </ParamField>
+  <ParamField query="contractaddress" type="string" initialValue="0xaaaebe6fe48e54f431b0c390cfaf0b017d09d42d">
+    Contract address of the ERC-20 token.
+  </ParamField>
+  <ParamField query="page" type="integer" initialValue="1">
+    Page number for pagination.
+  </ParamField>
+  <ParamField query="offset" type="integer" initialValue="10">
+    Number of records per page.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/tokeninfo.mdx
+++ b/api-reference/endpoint/tokeninfo.mdx
@@ -1,0 +1,26 @@
+---
+title: "Get Token Info by ContractAddress"
+api: "GET /v2/api"
+keywords: ["token info", "token metadata"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns project information and social links of a token" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="token">
+    Set to `token` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="tokeninfo">
+    Set to `tokeninfo` for this endpoint.
+  </ParamField>
+  <ParamField query="contractaddress" type="string" initialValue="0x0e3a2a1f2146d86a604adc220b4967a898d7fe07">
+    Contract address of the token to retrieve info for.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/tokensupply.mdx
+++ b/api-reference/endpoint/tokensupply.mdx
@@ -1,0 +1,26 @@
+---
+title: "Get ERC20-Token TotalSupply by ContractAddress"
+api: "GET /v2/api"
+keywords: ["token supply", "erc20 supply"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the current amount of an ERC-20 token in circulation" />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="tokensupply">
+    Set to `tokensupply` for this endpoint.
+  </ParamField>
+  <ParamField query="contractaddress" type="string" initialValue="0x57d90b64a1a57749b0f932f1a3395792e12e7055">
+    Contract address of the ERC-20 token.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/api-reference/endpoint/tokensupplyhistory.mdx
+++ b/api-reference/endpoint/tokensupplyhistory.mdx
@@ -1,0 +1,29 @@
+---
+title: "Get Historical ERC20-Token TotalSupply by ContractAddress & BlockNo"
+api: "GET /v2/api"
+keywords: ["token supply history", "erc20 supply history"]
+---
+
+import { chain } from '/snippets/custom-variables.mdx';
+import { CreditChip } from '/snippets/jsx-snippet.jsx';
+
+<CreditChip description="Returns the amount of an ERC-20 token in circulation at a specific block" pro={true} />
+
+  <ParamField query="chainid" type="string" initialValue="1">
+    Chain ID to query, eg `1` for Ethereum, `8453` for Base from our [supported chains](/development).
+  </ParamField>
+  <ParamField query="module" type="string" initialValue="stats">
+    Set to `stats` for this endpoint.
+  </ParamField>
+  <ParamField query="action" type="string" initialValue="tokensupplyhistory">
+    Set to `tokensupplyhistory` for this endpoint.
+  </ParamField>
+  <ParamField query="contractaddress" type="string" initialValue="0x57d90b64a1a57749b0f932f1a3395792e12e7055">
+    Contract address of the ERC-20 token.
+  </ParamField>
+  <ParamField query="blockno" type="integer" initialValue="8000000">
+    Block number to check total supply for.
+  </ParamField>
+  <ParamField query="apikey" type="string">
+    Your Etherscan API key. If you're still using a legacy key from another explorer like BscScan/Basescan and so on, please refer to this migration.
+  </ParamField>

--- a/docs.json
+++ b/docs.json
@@ -103,9 +103,56 @@
                   "api-reference/endpoint/ethgettransactionreceipt",
                   "api-reference/endpoint/ethcall",
                   "api-reference/endpoint/ethgetcode",
-                  "api-reference/endpoint/ethgetstorageat",
-                  "api-reference/endpoint/ethgasprice",
-                  "api-reference/endpoint/ethestimategas"
+                "api-reference/endpoint/ethgetstorageat",
+                "api-reference/endpoint/ethgasprice",
+                "api-reference/endpoint/ethestimategas"
+              ]
+              },
+              {
+                "group": "Logs",
+                "pages": [
+                  "api-reference/endpoint/getlogs",
+                  "api-reference/endpoint/getlogs-topics",
+                  "api-reference/endpoint/getlogs-address-topics"
+                ]
+              },
+              {
+                "group": "Stats",
+                "pages": [
+                  "api-reference/endpoint/ethsupply",
+                  "api-reference/endpoint/ethsupply2",
+                  "api-reference/endpoint/ethprice",
+                  "api-reference/endpoint/chainsize",
+                  "api-reference/endpoint/nodecount",
+                  "api-reference/endpoint/dailytxnfee",
+                  "api-reference/endpoint/dailynewaddress",
+                  "api-reference/endpoint/dailynetutilization",
+                  "api-reference/endpoint/dailyavghashrate",
+                  "api-reference/endpoint/dailytx",
+                  "api-reference/endpoint/dailyavgnetdifficulty",
+                  "api-reference/endpoint/ethdailyprice"
+                ]
+              },
+              {
+                "group": "Transactions",
+                "pages": [
+                  "api-reference/endpoint/getstatus",
+                  "api-reference/endpoint/gettxreceiptstatus"
+                ]
+              },
+              {
+                "group": "Tokens",
+                "pages": [
+                  "api-reference/endpoint/tokensupply",
+                  "api-reference/endpoint/tokenbalance",
+                  "api-reference/endpoint/tokensupplyhistory",
+                  "api-reference/endpoint/tokenbalancehistory",
+                  "api-reference/endpoint/tokenholderlist",
+                  "api-reference/endpoint/tokenholdercount",
+                  "api-reference/endpoint/tokeninfo",
+                  "api-reference/endpoint/addresstokenbalance",
+                  "api-reference/endpoint/addresstokennftbalance",
+                  "api-reference/endpoint/addresstokennftinventory"
                 ]
               }
             ]


### PR DESCRIPTION
## Summary
- document log retrieval endpoints
- add stats, transaction, and token API docs
- include new endpoints in navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b0745e2f348333ad42cc61486b91ff